### PR TITLE
Fix - cleanup index on rebuild

### DIFF
--- a/src/Kentico.Xperience.Lucene/Services/ILuceneIndexService.cs
+++ b/src/Kentico.Xperience.Lucene/Services/ILuceneIndexService.cs
@@ -6,7 +6,9 @@ namespace Kentico.Xperience.Lucene.Services;
 
 public interface ILuceneIndexService
 {
-    T UseWriter<T>(LuceneIndex index, Func<IndexWriter, T> useIndexWriter);
+    T UseWriter<T>(LuceneIndex index, Func<IndexWriter, T> useIndexWriter, OpenMode openMode = OpenMode.CREATE_OR_APPEND);
+
+    void ResetIndex(LuceneIndex index);
 
     TResult UseSearcher<TResult>(LuceneIndex index, Func<IndexSearcher, TResult> useIndexSearcher);
 }

--- a/src/Kentico.Xperience.Lucene/Services/Implementations/DefaultLuceneClient.cs
+++ b/src/Kentico.Xperience.Lucene/Services/Implementations/DefaultLuceneClient.cs
@@ -134,6 +134,7 @@ internal class DefaultLuceneClient : ILuceneClient
     {
         // Clear statistics cache so listing displays updated data after rebuild
         cacheAccessor.Remove(CACHEKEY_STATISTICS);
+        luceneIndexService.ResetIndex(luceneIndex);
 
         var indexedNodes = new List<TreeNode>();
         foreach (var includedPathAttribute in luceneIndex.IncludedPaths)

--- a/src/Kentico.Xperience.Lucene/Services/Implementations/DefaultLuceneIndexService.cs
+++ b/src/Kentico.Xperience.Lucene/Services/Implementations/DefaultLuceneIndexService.cs
@@ -10,8 +10,7 @@ namespace Kentico.Xperience.Lucene.Services.Implementations;
 public class DefaultLuceneIndexService : ILuceneIndexService
 {
     private const LuceneVersion LUCENE_VERSION = LuceneVersion.LUCENE_48;
-
-    public TResult UseWriter<TResult>(LuceneIndex index, Func<IndexWriter, TResult> useIndexWriter)
+    public TResult UseWriter<TResult>(LuceneIndex index, Func<IndexWriter, TResult> useIndexWriter, OpenMode openMode = OpenMode.CREATE_OR_APPEND)
     {
         using LuceneDirectory indexDir = FSDirectory.Open(index.IndexPath);
 
@@ -24,6 +23,11 @@ public class DefaultLuceneIndexService : ILuceneIndexService
 
         return useIndexWriter(writer);
     }
+
+    public void ResetIndex(LuceneIndex index) => UseWriter(index, (IndexWriter writer) => {
+        writer.DeleteAll();
+        return true;
+    }, OpenMode.CREATE);
 
     public TResult UseSearcher<TResult>(LuceneIndex index, Func<IndexSearcher, TResult> useIndexSearcher)
     {


### PR DESCRIPTION
# Motivation

Index should be cleared first on rebuild so that there are no remining old indexed items.

