### PR TITLE
Crawler example - move base url to configuration & improve logging

### DIFF
--- a/src/Kentico.Xperience.Lucene.Sample/Search/WebCrawlerService.cs
+++ b/src/Kentico.Xperience.Lucene.Sample/Search/WebCrawlerService.cs
@@ -1,37 +1,56 @@
-﻿using CMS.DocumentEngine;
+﻿using CMS.Core;
+using CMS.DocumentEngine;
+using CMS.Helpers;
 using Kentico.Content.Web.Mvc;
 using Microsoft.Net.Http.Headers;
 
 namespace DancingGoat.Search;
-
 public class WebCrawlerService
 {
     private readonly HttpClient httpClient;
     private readonly IPageUrlRetriever urlRetriever;
+    private readonly IEventLogService eventLogService;
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S125:Sections of code should not be commented out", Justification = "Comments contain possible alternative solutions")]
-    public WebCrawlerService(HttpClient httpClient, IPageUrlRetriever urlRetriever)
+    public WebCrawlerService(HttpClient httpClient, IPageUrlRetriever urlRetriever, IEventLogService eventLogService)
     {
         this.httpClient = httpClient;
         // configure the client inside constructor if needed (add custom headers etc.)
         this.httpClient.DefaultRequestHeaders.Add(HeaderNames.UserAgent, "SearchCrawler");
-        this.httpClient.BaseAddress = new Uri(DocumentURLProvider.GetDomainUrl("DancingGoatCore"));
-        // alternatively specify custom url or load it from settings
-        // this.httpClient.BaseAddress = new Uri("http://localhost:41489/");
+        // get crawler base url from settings or site configuration, make sure that WebCrawlerBaseUrl is correct
+        string baseUrl = ValidationHelper.GetString(Service.Resolve<IAppSettingsService>()["WebCrawlerBaseUrl"], DocumentURLProvider.GetDomainUrl("DancingGoatCore"));
+        this.httpClient.BaseAddress = new Uri(baseUrl);
 
         this.urlRetriever = urlRetriever;
+        this.eventLogService = eventLogService;
     }
 
     public async Task<string> CrawlNode(TreeNode node)
     {
-        string url = urlRetriever.Retrieve(node).RelativePath.TrimStart('~');
-        // urlRetriever.Retrieve(node).AbsolutePath and no BaseAddress could be used as an alternative
-        return await CrawlPage(url);
+        try
+        {
+            // use relative path, '/' is stripped to handle base urls which are not domain root
+            string url = urlRetriever.Retrieve(node).RelativePath.TrimStart('~').TrimStart('/');
+            // urlRetriever.Retrieve(node).AbsolutePath and no BaseAddress could be used as an alternative
+            return await CrawlPage(url);
+        }
+        catch (Exception ex)
+        {
+            eventLogService.LogException(nameof(WebCrawlerService), nameof(CrawlNode), ex, 0, $"NodeAliasPath: {node.NodeAliasPath}");
+        }
+        return "";
     }
 
     public async Task<string> CrawlPage(string url)
     {
-        var response = await httpClient.GetAsync(url);
-        return await response.Content.ReadAsStringAsync();
+        try
+        {
+            var response = await httpClient.GetAsync(url);
+            return await response.Content.ReadAsStringAsync();
+        }
+        catch (Exception ex)
+        {
+            eventLogService.LogException(nameof(WebCrawlerService), nameof(CrawlPage), ex, 0, $"Url: {url}");
+        }
+        return "";
     }
 }

--- a/src/Kentico.Xperience.Lucene.Sample/appsettings.json
+++ b/src/Kentico.Xperience.Lucene.Sample/appsettings.json
@@ -14,14 +14,15 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "CMSConnectionString": ""
+    "CMSConnectionString": "Data Source=localhost;Initial Catalog=Dancing.Goat;Integrated Security=False;Persist Security Info=False;User ID=Kentico;Password=Password.;Connect Timeout=60;Encrypt=False;Current Language=English;"
   },
   "CMSHashStringSalt": "195a79ed-c559-42d8-b801-5857fc07ab1c",
-
-  "CMSAdminClientModuleSettings": {
-    "kentico-xperience-integrations-lucene": {
-      "Mode": "Proxy",
-      "Port": 3009
-    }
-  }
+  "WebCrawlerBaseUrl": "http://localhost:41489/"
+  //// uncomment for client admin module development
+  //"CMSAdminClientModuleSettings": {
+  //  "kentico-xperience-integrations-lucene": {
+  //    "Mode": "Proxy",
+  //    "Port": 3009
+  //  }
+  //}
 }


### PR DESCRIPTION
# Motivation
Based on experience with module usage following features we added
- make crawler base url configurable
- add more logging to the crawler

CMSAdminClientModuleSettings was commented out because it causes trouble for users who just want to view the example
Developer who wants to improve the admin module could uncomment it on local dev machine