### PR TITLE
Fix/culture code for retriever

### DIFF
--- a/src/Kentico.Xperience.Lucene.Sample/Search/WebCrawlerService.cs
+++ b/src/Kentico.Xperience.Lucene.Sample/Search/WebCrawlerService.cs
@@ -28,8 +28,8 @@ public class WebCrawlerService
     {
         try
         {
-            // use relative path, '/' is stripped to handle base urls which are not domain root
-            string url = urlRetriever.Retrieve(node).RelativePath.TrimStart('~').TrimStart('/');
+            // use relative path, '/' is stripped to handle base urls whicha are not domain root
+            string url = urlRetriever.Retrieve(node, node.DocumentCulture).RelativePath.TrimStart('~').TrimStart('/');
             // urlRetriever.Retrieve(node).AbsolutePath and no BaseAddress could be used as an alternative
             return await CrawlPage(url);
         }

--- a/src/Kentico.Xperience.Lucene.Sample/Search/WebCrawlerService.cs
+++ b/src/Kentico.Xperience.Lucene.Sample/Search/WebCrawlerService.cs
@@ -28,7 +28,7 @@ public class WebCrawlerService
     {
         try
         {
-            // use relative path, '/' is stripped to handle base urls whicha are not domain root
+            // use relative path, '/' is stripped to handle base urls which are not domain root
             string url = urlRetriever.Retrieve(node, node.DocumentCulture).RelativePath.TrimStart('~').TrimStart('/');
             // urlRetriever.Retrieve(node).AbsolutePath and no BaseAddress could be used as an alternative
             return await CrawlPage(url);

--- a/src/Kentico.Xperience.Lucene/Services/Implementations/DefaultLuceneModelGenerator.cs
+++ b/src/Kentico.Xperience.Lucene/Services/Implementations/DefaultLuceneModelGenerator.cs
@@ -259,10 +259,10 @@ internal class DefaultLuceneModelGenerator : ILuceneModelGenerator
         string url;
         try
         {
-            url = urlRetriever.Retrieve(node).RelativePath;
+            url = urlRetriever.Retrieve(node, node.DocumentCulture).RelativePath;
         }
         catch (Exception)
-        {
+        { 
             // Retrieve can throw an exception when processing a page update LuceneQueueItem
             // and the page was deleted before the update task has processed. In this case, upsert an
             // empty URL


### PR DESCRIPTION
Fixed an issue where pageUrlRetriever takes into account default culture code of the hosting device instead of the culture code of the Node.
This issue was throwing an exception on a device of a different culture than the culture of the site and whole crawling was effectively useless.