### PR TITLE
fix(lucene storage): incorrect usage of Path.Combine outside windows

### DIFF
--- a/src/Kentico.Xperience.Lucene.Core/Indexing/ILuceneIndexStorageStrategy.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Indexing/ILuceneIndexStorageStrategy.cs
@@ -69,10 +69,10 @@ internal class GenerationStorageStrategy : ILuceneIndexStorageStrategy
     {
         (string? path, string? taxonomyPath, int generation, bool _) = storage;
 
-        string delBase = Path.Combine(path, $@"..\{IndexDeletionDirectoryName}");
+        string delBase = Path.Combine(path, "..", IndexDeletionDirectoryName);
         Directory.CreateDirectory(delBase);
 
-        string delPath = Path.Combine(path, $@"..\{IndexDeletionDirectoryName}\{generation:0000000}");
+        string delPath = Path.Combine(path, "..", IndexDeletionDirectoryName, $"{generation:0000000}");
         try
         {
             Directory.Move(path, delPath);
@@ -87,7 +87,7 @@ internal class GenerationStorageStrategy : ILuceneIndexStorageStrategy
 
         if (!string.IsNullOrWhiteSpace(taxonomyPath) && Directory.Exists(taxonomyPath))
         {
-            string delPathTaxon = Path.Combine(path, $@"..\{IndexDeletionDirectoryName}\{generation:0000000}_taxon");
+            string delPathTaxon = Path.Combine(path, "..", IndexDeletionDirectoryName, $"{generation:0000000}_taxon");
             try
             {
                 Directory.Move(taxonomyPath, delPathTaxon);


### PR DESCRIPTION
# Motivation

Fixes issue with rebuilding where deleted items would cause error on linux because of incorrect path

## Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

Run application. In Lucene admin ui module try and create and rebuild an index. When it has some indexed items, try to change configuration so that there would be less items. Then rebuild. There should be no error on any enviroment