### PR TITLE
Fix/compare website channel name on publish event

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text eol=crlf
 *.png binary
+*.jpg binary

--- a/src/Kentico.Xperience.Lucene.Core/Indexing/IndexedItemModelExtensions.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Indexing/IndexedItemModelExtensions.cs
@@ -36,6 +36,11 @@ internal static class IndexedItemModelExtensions
             return false;
         }
 
+        if (!string.Equals(item.WebsiteChannelName, luceneIndex.WebSiteChannelName))
+        {
+            return false;
+        }
+
         if (!luceneIndex.LanguageNames.Exists(x => x == item.LanguageName))
         {
             return false;


### PR DESCRIPTION
# Motivation

* Fixes the issue #68 with web items not being compared against WebSiteChannelName of an index on publish event