### PR TITLE
Fixed FindItemsToReindex returns empty list

### DIFF
--- a/src/Kentico.Xperience.Lucene.Core/Indexing/DefaultLuceneIndexingStrategy.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Indexing/DefaultLuceneIndexingStrategy.cs
@@ -36,6 +36,6 @@ public class DefaultLuceneIndexingStrategy : ILuceneIndexingStrategy
     public virtual async Task<IEnumerable<IIndexEventItemModel>> FindItemsToReindex(IndexEventWebPageItemModel changedItem) => await Task.FromResult(new List<IIndexEventItemModel>() { changedItem });
 
     /// <inheritdoc />
-    public virtual async Task<IEnumerable<IIndexEventItemModel>> FindItemsToReindex(IndexEventReusableItemModel changedItem) => await Task.FromResult(new List<IIndexEventItemModel>());
+    public virtual async Task<IEnumerable<IIndexEventItemModel>> FindItemsToReindex(IndexEventReusableItemModel changedItem) => await Task.FromResult(new List<IIndexEventItemModel>() { changedItem });
 }
 


### PR DESCRIPTION
FindItemsToReindex was always returning empty list which was leading to not updating content items in index

# Motivation

Which issue does this fix? Fixes #122
