### PR TITLE
Corrected documentation link for the "No indexes" warning

### DIFF
--- a/src/Kentico.Xperience.Lucene.Admin/UIPages/IndexListingPage.cs
+++ b/src/Kentico.Xperience.Lucene.Admin/UIPages/IndexListingPage.cs
@@ -57,7 +57,7 @@ internal class IndexListingPage : ListingPage
                 new()
                 {
                     Headline = "No indexes",
-                    Content = "No Lucene indexes registered. See <a target='_blank' href='https://github.com/Kentico/kentico-xperience-lucene'>our instructions</a> to read more about creating and registering Lucene indexes.",
+                    Content = "No Lucene indexes registered. See <a target='_blank' href='https://github.com/Kentico/xperience-by-kentico-lucene'>our instructions</a> to read more about creating and registering Lucene indexes.",
                     ContentAsHtml = true,
                     Type = CalloutType.FriendlyWarning,
                     Placement = CalloutPlacement.OnDesk


### PR DESCRIPTION
This pull request makes a small update to the help text shown when no Lucene indexes are registered. The change updates the documentation link to point to the correct GitHub repository.

* Updated the URL in the "No indexes" callout content to reference the new Lucene documentation repository (`IndexListingPage.cs`).