### PR TITLE
Fix link to Auto-Reindexing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use `Kentico.Xperience.Lucene.Core` in your Xperience by Kentico project for Luc
 Use `Kentico.Xperience.Lucene.Admin` in your Xperience by Kentico Administration project for Lucene Search Administration UI managment.
 
 **Important Compatibility Notice**  
-Lucene integration **requires persistent file system access** to store and manage indexes. In environments like **Kentico Xperience SaaS**, which do not provide persistent file system storage for indexes, the index data is lost during deployments or restarts. As a result, indexes must be rebuilt after each deployment to ensure correct search functionality. See [Auto-Reindexing](Auto-Reindexing-After-Deployment.md) to address this issue.
+Lucene integration **requires persistent file system access** to store and manage indexes. In environments like **Kentico Xperience SaaS**, which do not provide persistent file system storage for indexes, the index data is lost during deployments or restarts. As a result, indexes must be rebuilt after each deployment to ensure correct search functionality. See [Auto-Reindexing](./docs/Auto-Reindexing-After-Deployment.md) to address this issue.
 
 ## Screenshots
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the location of the Auto-Reindexing guide. The main change is a fix to the link in the `README.md` file, ensuring it correctly points to the `Auto-Reindexing-After-Deployment.md` document within the `docs` directory.

Documentation update:

* Updated the link to the Auto-Reindexing guide in `README.md` to reference the correct path (`./docs/Auto-Reindexing-After-Deployment.md`).