### PR TITLE
Enhance Lucene auto-reindexing documentation

### DIFF
--- a/docs/Auto-Reindexing-After-Deployment.md
+++ b/docs/Auto-Reindexing-After-Deployment.md
@@ -4,7 +4,7 @@
 
 Lucene integration **requires persistent file system access** to store and manage indexes. In environments like **Kentico Xperience SaaS**, which do not provide persistent file system storage for indexes, the index data is lost during deployments or restarts. As a result, indexes must be rebuilt after each deployment to ensure correct search functionality.
 
-To address this issue, a new configuration option has been introduced to enable automatic reindexing. The solution adds a hosted service that periodically checks the application’s assembly version, compares it with the stored assembly version for each index, and updates it after a rebuild. If the versions differ, the index is automatically rebuilt.
+To address this issue, a new configuration option has been introduced to enable automatic reindexing. The solution adds a hosted service that periodically checks the application's assembly version, compares it with the stored assembly version for each index, and updates it after a rebuild. If the versions differ, the index is automatically rebuilt.
 
 **Note:** For this feature to work correctly, your project must have a build-time assembly version that changes with each deployment. One approach is to add the following to your `.csproj` file:
 ```xml
@@ -16,7 +16,11 @@ You can also use any other assembly versioning method, as long as it produces a 
 
 ## Configuration
 
-To enable the automatic assembly check and index rebuilding, add the following configuration to your `appsettings.json` file:
+To enable the automatic assembly check and index rebuilding, follow these steps:
+
+### 1. Add Configuration to appsettings.json
+
+Add the following configuration to your `appsettings.json` file:
 
 ```json
 "CMSLuceneSearch": {
@@ -27,3 +31,20 @@ To enable the automatic assembly check and index rebuilding, add the following c
         "CheckIntervalMinutes": 2 // Frequency of assembly version checks (in minutes). Default is 1 minute and the value can not be less than one minute.
     }
 }
+```
+
+### 2. Update Service Registration
+
+You must pass the configuration as a parameter to the `AddKenticoLucene` method in your service registration:
+
+```csharp
+services.AddKenticoLucene(builder =>
+{
+    builder.RegisterStrategy<AdvancedSearchIndexingStrategy>("DancingGoatExampleStrategy");
+    builder.RegisterStrategy<SimpleSearchIndexingStrategy>("DancingGoatMinimalExampleStrategy");
+    builder.RegisterStrategy<ReusableContentItemsIndexingStrategy>(nameof(ReusableContentItemsIndexingStrategy));
+    builder.RegisterAnalyzer<CzechAnalyzer>("Czech analyzer");
+}, configuration);
+```
+
+The `configuration` parameter allows the Lucene service to access the `PostStartupReindexingOptions` settings from your `appsettings.json` file.


### PR DESCRIPTION
This pull request updates the documentation for automatic Lucene index reindexing after deployment, making the configuration steps clearer and more detailed. The most important changes include breaking down the configuration process into step-by-step instructions and clarifying how to register the configuration with the Lucene service.

Documentation improvements:

* The configuration section now provides a step-by-step guide, first instructing users to add the necessary settings to `appsettings.json`, and then explaining how to update the service registration to pass the configuration to `AddKenticoLucene`. [[1]](diffhunk://#diff-5370fffc922dae3ffd184cd313860371787e74a64e53097216f1ce90795af153L19-R23) [[2]](diffhunk://#diff-5370fffc922dae3ffd184cd313860371787e74a64e53097216f1ce90795af153R34-R50)
* Clarified language and fixed minor formatting for consistency and readability throughout the documentation.