### PR TITLE
Add DrillSideways Support

### DIFF
--- a/docs/Search-index-querying.md
+++ b/docs/Search-index-querying.md
@@ -189,7 +189,7 @@ public LuceneSearchResultModel<GlobalSearchResultModel> DrillSidewaysSearch(
                 string[] subFacets = facet.Split(';', StringSplitOptions.RemoveEmptyEntries);
                 foreach (string subFacet in subFacets)
                 {
-                    drillDownQuery.Add(nameof(GlobalSearchResultModel.Taxonomy), subFacet);
+                    drillDownQuery.Add(strategy.FacetDimension, subFacet);
                 }
             }
 

--- a/docs/Search-index-querying.md
+++ b/docs/Search-index-querying.md
@@ -28,7 +28,14 @@ public class GlobalSearchResultModel
 
 Execute a search with a customized Lucene `Query` (like the `MatchAllDocsQuery`) using the ILuceneSearchService.
 You can use your `GlobalSearchResultModel` as a generic parameter of prepared class template `LuceneSearchResultModel<T>` class to retrieve the most often desired data from `ILuceneSearchService`.
-If you don't want to use [facets](Custom-index-strategy.md#Add-facets), use `UseSearcher` instead of `UseSearcherWithFacets` to query lucene indexes.
+
+### Search Methods
+
+The `ILuceneSearchService` provides three methods for different search scenarios:
+
+- **`UseSearcher`** - Use for basic search without facets.
+- **`UseSearcherWithFacets`** - Use for faceted search when you need to collect facet information.
+- **`UseSearcherWithDrillSideways`** - Use for advanced faceted search with drill-down capabilities. This works well for dynamic facet counts across multiple facet dimensions.
 
 ```csharp
 public class SearchService
@@ -149,6 +156,83 @@ public class SearchService
         Url = doc.Get("Url"),
         ContentType = doc.Get(nameof(GlobalSearchResultModel.ContentType)),
     };
+}
+```
+
+### Using Drill-Sideways Search
+
+For advanced faceted search with drill-down capabilities, use `UseSearcherWithDrillSideways`. This method enables you to perform drill-down queries while maintaining facet counts for unchosen facets, allowing users to see what results would be available if they chose different facet values.
+
+```csharp
+public LuceneSearchResultModel<GlobalSearchResultModel> DrillSidewaysSearch(
+    string indexName,
+    string searchText,
+    int pageSize = 20,
+    int page = 1,
+    string? facet = null,
+    string? sortBy = null)
+{
+    var index = luceneIndexManager.GetRequiredIndex(indexName);
+
+    // This query should contain term query, base filtering, scoring, etc... but NOT your facet filtering.
+    var query = GetTermQuery(searchText);
+
+    var result = luceneSearchService.UseSearcherWithDrillSideways(
+        index,
+        (searcher, drillSideways) =>
+        {
+            // DrillDownQuery wraps your base query.
+            var drillDownQuery = new DrillDownQuery(strategy.FacetsConfigFactory(), query);
+
+            if (!string.IsNullOrEmpty(facet))
+            {
+                string[] subFacets = facet.Split(';', StringSplitOptions.RemoveEmptyEntries);
+                foreach (string subFacet in subFacets)
+                {
+                    drillDownQuery.Add(nameof(GlobalSearchResultModel.Taxonomy), subFacet);
+                }
+            }
+
+            var sortOptions = GetSortOption(sortBy);
+            DrillSidewaysResult drillSidewaysResult;
+
+            if (sortOptions != null)
+            {
+                drillSidewaysResult = drillSideways.Search(drillDownQuery, MAX_RESULTS, new Sort(sortOptions));
+            }
+            else
+            {
+                drillSidewaysResult = drillSideways.Search(drillDownQuery, MAX_RESULTS);
+            }
+
+            var topDocs = drillSidewaysResult.Hits;
+            var facets = drillSidewaysResult.Facets;
+
+            pageSize = Math.Max(1, pageSize);
+            page = Math.Max(1, page);
+            int offset = pageSize * (page - 1);
+            int limit = pageSize;
+
+            return new LuceneSearchResultModel<GlobalSearchResultModel>
+            {
+                Query = searchText ?? string.Empty,
+                Page = page,
+                PageSize = pageSize,
+                TotalPages = topDocs.TotalHits <= 0 ? 0 : ((topDocs.TotalHits - 1) / pageSize) + 1,
+                TotalHits = topDocs.TotalHits,
+                Hits = topDocs.ScoreDocs
+                    .Skip(offset)
+                    .Take(limit)
+                    .Select(d => MapToResultItem(searcher.Doc(d.Doc)))
+                    .ToList(),
+                Facet = facet,
+                // Get facet counts for the dimension, including counts for unchosen facets
+                Facets = facets?.GetTopChildren(10, strategy.FacetDimension)?.LabelValues.ToArray() ?? []
+            };
+        }
+    );
+
+    return result;
 }
 ```
 

--- a/docs/Search-index-querying.md
+++ b/docs/Search-index-querying.md
@@ -35,7 +35,7 @@ The `ILuceneSearchService` provides three methods for different search scenarios
 
 - **`UseSearcher`** - Use for basic search without facets.
 - **`UseSearcherWithFacets`** - Use for faceted search when you need to collect facet information.
-- **`UseSearcherWithDrillSideways`** - Use for advanced faceted search with drill-down capabilities. This works well for dynamic facet counts across multiple facet dimensions.
+- **`UseSearcherWithDrillSideways`** - Use for advanced faceted search with drill-down capabilities and dynamic facet counts across multiple facet dimensions.
 
 ```csharp
 public class SearchService

--- a/src/Kentico.Xperience.Lucene.Core/Search/DefaultLuceneSearchService.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Search/DefaultLuceneSearchService.cs
@@ -24,6 +24,7 @@ internal class DefaultLuceneSearchService : ILuceneSearchService
         this.serviceProvider = serviceProvider;
     }
 
+    /// <inheritdoc />
     public TResult UseSearcher<TResult>(LuceneIndex index, Func<IndexSearcher, TResult> useIndexSearcher)
     {
         var storage = index.StorageContext.GetPublishedIndex();
@@ -43,6 +44,7 @@ internal class DefaultLuceneSearchService : ILuceneSearchService
         return useIndexSearcher(searcher);
     }
 
+    /// <inheritdoc />
     public TResult UseSearcherWithFacets<TResult>(LuceneIndex index, Query query, int n, Func<IndexSearcher, MultiFacets, TResult> useIndexSearcher)
     {
         var storage = index.StorageContext.GetPublishedIndex();
@@ -78,6 +80,7 @@ internal class DefaultLuceneSearchService : ILuceneSearchService
         return results;
     }
 
+    /// <inheritdoc />
     public TResult UseSearcherWithDrillSideways<TResult>(LuceneIndex index, Func<IndexSearcher, DrillSideways, TResult> useIndexSearcher)
     {
         var storage = index.StorageContext.GetPublishedIndex();

--- a/src/Kentico.Xperience.Lucene.Core/Search/DefaultLuceneSearchService.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Search/DefaultLuceneSearchService.cs
@@ -76,6 +76,36 @@ internal class DefaultLuceneSearchService : ILuceneSearchService
         var results = useIndexSearcher(searcher, facets);
 
         return results;
+    }
 
+    public TResult UseSearcherWithDrillSideways<TResult>(LuceneIndex index, Func<IndexSearcher, DrillSideways, TResult> useIndexSearcher)
+    {
+        var storage = index.StorageContext.GetPublishedIndex();
+        if (!System.IO.Directory.Exists(storage.Path))
+        {
+            // ensure index
+            indexService.UseIndexAndTaxonomyWriter(index, (writer, tw) =>
+            {
+                writer.Commit();
+                tw.Commit();
+                return true;
+            }, storage);
+        }
+
+        using LuceneDirectory indexDir = FSDirectory.Open(storage.Path);
+        using var reader = DirectoryReader.Open(indexDir);
+        var searcher = new IndexSearcher(reader);
+
+        using var taxonomyDir = FSDirectory.Open(storage.TaxonomyPath);
+        using var taxonomyReader = new DirectoryTaxonomyReader(taxonomyDir);
+
+        var strategy = serviceProvider.GetRequiredStrategy(index);
+        var config = strategy?.FacetsConfigFactory() ?? new FacetsConfig();
+
+        var drillSideways = new DrillSideways(searcher, config, taxonomyReader);
+
+        var results = useIndexSearcher(searcher, drillSideways);
+
+        return results;
     }
 }

--- a/src/Kentico.Xperience.Lucene.Core/Search/DefaultLuceneSearchService.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Search/DefaultLuceneSearchService.cs
@@ -24,6 +24,7 @@ internal class DefaultLuceneSearchService : ILuceneSearchService
         this.serviceProvider = serviceProvider;
     }
 
+
     /// <inheritdoc />
     public TResult UseSearcher<TResult>(LuceneIndex index, Func<IndexSearcher, TResult> useIndexSearcher)
     {
@@ -43,6 +44,7 @@ internal class DefaultLuceneSearchService : ILuceneSearchService
         var searcher = new IndexSearcher(reader);
         return useIndexSearcher(searcher);
     }
+
 
     /// <inheritdoc />
     public TResult UseSearcherWithFacets<TResult>(LuceneIndex index, Query query, int n, Func<IndexSearcher, MultiFacets, TResult> useIndexSearcher)
@@ -79,6 +81,7 @@ internal class DefaultLuceneSearchService : ILuceneSearchService
 
         return results;
     }
+
 
     /// <inheritdoc />
     public TResult UseSearcherWithDrillSideways<TResult>(LuceneIndex index, Func<IndexSearcher, DrillSideways, TResult> useIndexSearcher)

--- a/src/Kentico.Xperience.Lucene.Core/Search/ILuceneSearchService.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Search/ILuceneSearchService.cs
@@ -19,6 +19,7 @@ public interface ILuceneSearchService
     /// <returns>The result of the search operation.</returns>
     TResult UseSearcher<TResult>(LuceneIndex index, Func<IndexSearcher, TResult> useIndexSearcher);
 
+
     /// <summary>
     /// Executes a search operation with faceted search capabilities using <see cref="MultiFacets"/>.
     /// </summary>
@@ -29,6 +30,7 @@ public interface ILuceneSearchService
     /// <param name="useIndexSearcher">A function that performs the search using the <see cref="IndexSearcher"/> and <see cref="MultiFacets"/>.</param>
     /// <returns>The result of the search operation with facet information.</returns>
     TResult UseSearcherWithFacets<TResult>(LuceneIndex index, Query query, int n, Func<IndexSearcher, MultiFacets, TResult> useIndexSearcher);
+
 
     /// <summary>
     /// Executes a search operation with drill-sideways faceted search capabilities using <see cref="DrillSideways"/>.

--- a/src/Kentico.Xperience.Lucene.Core/Search/ILuceneSearchService.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Search/ILuceneSearchService.cs
@@ -13,4 +13,6 @@ public interface ILuceneSearchService
     TResult UseSearcher<TResult>(LuceneIndex index, Func<IndexSearcher, TResult> useIndexSearcher);
 
     TResult UseSearcherWithFacets<TResult>(LuceneIndex index, Query query, int n, Func<IndexSearcher, MultiFacets, TResult> useIndexSearcher);
+
+    TResult UseSearcherWithDrillSideways<TResult>(LuceneIndex index, Func<IndexSearcher, DrillSideways, TResult> useIndexSearcher);
 }

--- a/src/Kentico.Xperience.Lucene.Core/Search/ILuceneSearchService.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Search/ILuceneSearchService.cs
@@ -10,9 +10,34 @@ namespace Kentico.Xperience.Lucene.Core.Search;
 /// </summary>
 public interface ILuceneSearchService
 {
+    /// <summary>
+    /// Executes a search operation using a Lucene <see cref="IndexSearcher"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result returned by the search operation.</typeparam>
+    /// <param name="index">The Lucene index to search.</param>
+    /// <param name="useIndexSearcher">A function that performs the search using the <see cref="IndexSearcher"/>.</param>
+    /// <returns>The result of the search operation.</returns>
     TResult UseSearcher<TResult>(LuceneIndex index, Func<IndexSearcher, TResult> useIndexSearcher);
 
+    /// <summary>
+    /// Executes a search operation with faceted search capabilities using <see cref="MultiFacets"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result returned by the search operation.</typeparam>
+    /// <param name="index">The Lucene index to search.</param>
+    /// <param name="query">The query to execute for collecting facet data.</param>
+    /// <param name="n">The maximum number of results to collect for faceting.</param>
+    /// <param name="useIndexSearcher">A function that performs the search using the <see cref="IndexSearcher"/> and <see cref="MultiFacets"/>.</param>
+    /// <returns>The result of the search operation with facet information.</returns>
     TResult UseSearcherWithFacets<TResult>(LuceneIndex index, Query query, int n, Func<IndexSearcher, MultiFacets, TResult> useIndexSearcher);
 
+    /// <summary>
+    /// Executes a search operation with drill-sideways faceted search capabilities using <see cref="DrillSideways"/>.
+    /// This method enables drill-down queries while maintaining facet counts for unchosen facets,
+    /// allowing users to see what results would be available if they chose different facet values.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result returned by the search operation.</typeparam>
+    /// <param name="index">The Lucene index to search.</param>
+    /// <param name="useIndexSearcher">A function that performs the search using the <see cref="IndexSearcher"/> and <see cref="DrillSideways"/>.</param>
+    /// <returns>The result of the search operation with drill-sideways facet information.</returns>
     TResult UseSearcherWithDrillSideways<TResult>(LuceneIndex index, Func<IndexSearcher, DrillSideways, TResult> useIndexSearcher);
 }


### PR DESCRIPTION
# Motivation

Which issue does this fix? Fixes #`issue number`
No GitHub Issue, I can make one if needed.

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?
This change adds support for using DrillSideways to provide accurate, dynamic facet counts.

## Background

The current implementation in the package, as shown in the documentation, passes the base query without drilldown filters to the FacetCollector. This results in static facet counts that represent how many documents have a given facet, regardless of the user’s current selections.

<img width="891" height="841" alt="image" src="https://github.com/user-attachments/assets/8aed3889-5be2-4c54-9b3d-8d544c0aeafb" />

Our clients want dynamic facet counts that respond to user selections. We first attempted this by passing the filtered query, including drilldown filters, to both the IndexSearcher and the FacetCollector. While this allowed facet counts to change as filters were applied, the counts were misleading. Facets that appeared to have zero results could still add items when selected.
 
<img width="987" height="970" alt="image" src="https://github.com/user-attachments/assets/5285c7fc-bdbc-4654-8fb8-83e73d653315" />

## Solution

DrillSideways addresses this problem by calculating facet counts independently for each facet dimension. This enables sideways exploration, where users can see how many results would be added by selecting a new value in a different facet group.

This behavior closely matches Azure Search facet counts, which our clients find intuitive. Using DrillSideways allows us to achieve similar UX while retaining the cost and flexibility benefits of Lucene.

<img width="961" height="850" alt="image" src="https://github.com/user-attachments/assets/aa050d7f-2e31-4c5c-9fae-63b4739e7ad8" />

### Implementation details

To support DrillSideways, DefaultLuceneSearchService needs access to the TaxonomyReader in order to construct the DrillSideways instance. To keep the API simple for package consumers, I added a method to the interface that returns a DrillSideways instance directly rather than exposing the underlying reader or searcher configuration.

## Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [X] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

This requires a search implementation with multiple facet dimensions.

Apply filters across different facets and observe the counts. Facet values should update dynamically to reflect how many results would be added if selected, allowing users to explore sideways across dimensions. The attached screenshots demonstrate the expected behavior.