### PR TITLE
Replaced corrupted zip with template zip from original dancinggoat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -48,3 +48,5 @@ tsconfig.json       linguist-language=JSON-with-Comments
 
 *.woff              binary
 *.woff2             binary
+
+*.zip               binary


### PR DESCRIPTION
This pull request makes a minor update to the `.gitattributes` file by marking `.zip` files as binary. This ensures that Git handles ZIP archives appropriately and avoids potential issues with line ending conversions or diffing.# Motivation

Which issue does this fix? Fixes #`issue number`

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

Dancing goat sample couldn't be deployed using dbmanager

## Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

If manual testing is required, what are the steps?
