### PR TITLE
Restore the original mixed case codec names

### DIFF
--- a/src/Kentico.Xperience.Lucene.Core/Indexing/DefaultLuceneConfigurationStorageService.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Indexing/DefaultLuceneConfigurationStorageService.cs
@@ -48,10 +48,7 @@ internal class DefaultLuceneConfigurationStorageService : ILuceneConfigurationSt
     /// <inheritdoc />
     public bool TryCreateIndex(LuceneIndexModel configuration)
     {
-        var existingIndex = indexProvider.Get()
-            .WhereEquals(nameof(LuceneIndexItemInfo.LuceneIndexItemIndexName), configuration.IndexName)
-            .TopN(1)
-            .FirstOrDefault();
+        var existingIndex = indexProvider.Get(configuration.IndexName);
 
         if (existingIndex is not null)
         {
@@ -136,7 +133,7 @@ internal class DefaultLuceneConfigurationStorageService : ILuceneConfigurationSt
     /// <inheritdoc />
     public async Task<LuceneIndexModel?> GetIndexDataOrNullAsync(int indexId)
     {
-        var indexInfo = indexProvider.Get().WithID(indexId).FirstOrDefault();
+        var indexInfo = indexProvider.Get(indexId);
         if (indexInfo == default)
         {
             return default;
@@ -159,7 +156,7 @@ internal class DefaultLuceneConfigurationStorageService : ILuceneConfigurationSt
     /// <inheritdoc />
     public async Task<LuceneIndexModel?> GetIndexDataOrNullAsync(string indexName)
     {
-        var indexInfo = indexProvider.Get().WhereEquals(nameof(LuceneIndexItemInfo.LuceneIndexItemIndexName), indexName).FirstOrDefault();
+        var indexInfo = indexProvider.Get(indexName);
         if (indexInfo == default)
         {
             return default;
@@ -215,10 +212,7 @@ internal class DefaultLuceneConfigurationStorageService : ILuceneConfigurationSt
     {
         configuration.IndexName = RemoveWhitespacesUsingStringBuilder(configuration.IndexName ?? string.Empty);
 
-        var indexInfo = indexProvider.Get()
-            .WhereEquals(nameof(LuceneIndexItemInfo.LuceneIndexItemId), configuration.Id)
-            .TopN(1)
-            .FirstOrDefault();
+        var indexInfo = indexProvider.Get(configuration.Id);
 
         if (indexInfo is null)
         {

--- a/src/Kentico.Xperience.Lucene.Core/InfoModels/LuceneIndexItem/LuceneIndexItemInfo.generated.cs
+++ b/src/Kentico.Xperience.Lucene.Core/InfoModels/LuceneIndexItem/LuceneIndexItemInfo.generated.cs
@@ -14,7 +14,8 @@ namespace Kentico.Xperience.Lucene.Core;
 /// <summary>
 /// Data container class for <see cref="LuceneIndexItemInfo"/>.
 /// </summary>
-public partial class LuceneIndexItemInfo : AbstractInfo<LuceneIndexItemInfo, IInfoProvider<LuceneIndexItemInfo>>
+[InfoCache(InfoCacheBy.ID | InfoCacheBy.Name, Priority = InfoCachePriority.NotRemovable)]
+public partial class LuceneIndexItemInfo : AbstractInfo<LuceneIndexItemInfo, IInfoProvider<LuceneIndexItemInfo>>, IInfoWithName, IInfoWithId
 {
     /// <summary>
     /// Object type.

--- a/src/Kentico.Xperience.Lucene.Core/Store/CmsIODirectory.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Store/CmsIODirectory.cs
@@ -285,7 +285,7 @@ internal class CmsIODirectory : BaseDirectory
     /// underscores (e.g. <c>_a_Lucene41_0.doc</c>). This method splits on <c>_</c> and maps
     /// any segment that matches a registered codec name back to its canonical casing.
     /// </summary>
-    private static string RestoreCodecNameCase(string fileName)
+    internal static string RestoreCodecNameCase(string fileName)
     {
         var lookup = codecNameLookup.Value;
         var parts = fileName.Split('_');
@@ -303,8 +303,8 @@ internal class CmsIODirectory : BaseDirectory
 
 
     /// <summary>
-    /// Builds a case-insensitive lookup from lowercase codec/format name to the original-case
-    /// name as registered in Lucene's PostingsFormat, DocValuesFormat and Codec factories.
+    /// Builds a case-insensitive lookup from codec/format name to the canonical casing
+    /// as registered in Lucene's PostingsFormat, DocValuesFormat and Codec factories.
     /// </summary>
     private static Dictionary<string, string> BuildCodecNameLookup()
     {

--- a/src/Kentico.Xperience.Lucene.Core/Store/CmsIODirectory.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Store/CmsIODirectory.cs
@@ -1,4 +1,6 @@
+using Lucene.Net.Codecs;
 using Lucene.Net.Store;
+using Lucene.Net.Util;
 
 using CmsDirectory = CMS.IO.Directory;
 using CmsDirectoryInfo = CMS.IO.DirectoryInfo;
@@ -20,6 +22,15 @@ namespace Kentico.Xperience.Lucene.Core.Store;
 /// </summary>
 internal class CmsIODirectory : BaseDirectory
 {
+    // CMS.IO lowercases blob names on case-sensitive backends like Azure Blob Storage.
+    // Lucene's per-field codec files embed the codec name in the filename with mixed casing,
+    // e.g. _a_Lucene41_0.doc. When stored via CMS.IO these become _a_lucene41_0.doc.
+    // We use the Lucene codec registries to build a case-insensitive lookup so ListAll()
+    // can return the original-case names that Lucene embedded in the segments file.
+    private static readonly Lazy<IReadOnlyDictionary<string, string>> codecNameLookup =
+        new(BuildCodecNameLookup);
+
+
     /// <summary>
     /// Opens a directory at the specified path for input/output operations using the default lock factory.
     /// </summary>
@@ -68,6 +79,9 @@ internal class CmsIODirectory : BaseDirectory
 
     /// <summary>
     /// Returns an array of strings, one for each file in the directory.
+    /// Restores mixed-case codec names that were lowercased by the CMS.IO storage backend
+    /// (e.g. Azure Blob Storage), so Lucene's IndexFileDeleter can match filenames against
+    /// the names recorded in the segments file.
     /// </summary>
     public override string[] ListAll()
     {
@@ -75,8 +89,7 @@ internal class CmsIODirectory : BaseDirectory
         EnsureDirectoryExists();
 
         var freshInfo = CmsDirectoryInfo.New(DirectoryPath);
-        var files = freshInfo.GetFiles();
-        return files.Select(f => f.Name).ToArray();
+        return [.. freshInfo.GetFiles().Select(f => RestoreCodecNameCase(f.Name))];
     }
 
 
@@ -264,4 +277,64 @@ internal class CmsIODirectory : BaseDirectory
             throw new ObjectDisposedException(GetType().FullName, "This directory has been closed.");
         }
     }
+
+
+    /// <summary>
+    /// Restores the original mixed-case codec name in a filename that was lowercased by the
+    /// storage backend. Lucene per-field codec files embed the codec or format name between
+    /// underscores (e.g. <c>_a_Lucene41_0.doc</c>). This method splits on <c>_</c> and maps
+    /// any segment that matches a registered codec name back to its canonical casing.
+    /// </summary>
+    private static string RestoreCodecNameCase(string fileName)
+    {
+        var lookup = codecNameLookup.Value;
+        var parts = fileName.Split('_');
+
+        for (int i = 0; i < parts.Length; i++)
+        {
+            if (lookup.TryGetValue(parts[i], out string? original))
+            {
+                parts[i] = original;
+            }
+        }
+
+        return string.Join('_', parts);
+    }
+
+
+    /// <summary>
+    /// Builds a case-insensitive lookup from lowercase codec/format name to the original-case
+    /// name as registered in Lucene's PostingsFormat, DocValuesFormat and Codec factories.
+    /// </summary>
+    private static Dictionary<string, string> BuildCodecNameLookup()
+    {
+        var lookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (PostingsFormat.GetPostingsFormatFactory() is IServiceListable postingsListable)
+        {
+            foreach (string name in postingsListable.AvailableServices)
+            {
+                lookup[name] = name;
+            }
+        }
+
+        if (DocValuesFormat.GetDocValuesFormatFactory() is IServiceListable docValuesListable)
+        {
+            foreach (string name in docValuesListable.AvailableServices)
+            {
+                lookup[name] = name;
+            }
+        }
+
+        if (Codec.GetCodecFactory() is IServiceListable codecListable)
+        {
+            foreach (string name in codecListable.AvailableServices)
+            {
+                lookup[name] = name;
+            }
+        }
+
+        return lookup;
+    }
 }
+

--- a/tests/Kentico.Xperience.Lucene.Tests/Store/CmsIODirectoryTests.cs
+++ b/tests/Kentico.Xperience.Lucene.Tests/Store/CmsIODirectoryTests.cs
@@ -1,0 +1,43 @@
+using Kentico.Xperience.Lucene.Core.Store;
+
+namespace Kentico.Xperience.Lucene.Tests.Store;
+
+[TestFixture]
+public class CmsIODirectoryRestoreCodecNameCaseTests
+{
+    [TestCase("_a_lucene41_0.doc", "_a_Lucene41_0.doc")]
+    [TestCase("_a_lucene40_0.doc", "_a_Lucene40_0.doc")]
+    [TestCase("_b_lucene45_0.dvd", "_b_Lucene45_0.dvd")]
+    [TestCase("_c_lucene42_0.dvm", "_c_Lucene42_0.dvm")]
+    [TestCase("_a_LUCENE41_0.doc", "_a_Lucene41_0.doc")]
+    public void RestoreCodecNameCase_KnownCodecName_RestoresCanonicalCasing(string input, string expected)
+    {
+        string result = CmsIODirectory.RestoreCodecNameCase(input);
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+
+    [TestCase("segments_1")]
+    [TestCase("segments.gen")]
+    [TestCase("write.lock")]
+    [TestCase("_a.cfe")]
+    [TestCase("_a.cfs")]
+    [TestCase("_b.si")]
+    public void RestoreCodecNameCase_FilesWithoutCodecName_AreUnchanged(string input)
+    {
+        string result = CmsIODirectory.RestoreCodecNameCase(input);
+
+        Assert.That(result, Is.EqualTo(input));
+    }
+
+
+    [TestCase("_a_unknownformat_0.doc")]
+    [TestCase("_b_mycodec_1.dvd")]
+    public void RestoreCodecNameCase_UnknownCodecName_IsUnchanged(string input)
+    {
+        string result = CmsIODirectory.RestoreCodecNameCase(input);
+
+        Assert.That(result, Is.EqualTo(input));
+    }
+}


### PR DESCRIPTION
This pull request improves the Lucene index integration in Kentico Xperience by optimizing how index information is retrieved and by addressing case-sensitivity issues with codec filenames in cloud storage environments. The changes streamline index lookups and ensure compatibility with Lucene's expectations for file naming, especially on case-sensitive backends like Azure Blob Storage.

**Index lookup optimizations:**
- Refactored the use of `indexProvider.Get()` throughout `DefaultLuceneConfigurationStorageService` to call the more efficient overloads that directly accept index name or ID, simplifying and optimizing index retrieval logic. [[1]](diffhunk://#diff-c1bb2180a9c1a5434b1f5daeda984091432f1f212bd36a43f9a5e275b14dd5f7L51-R51) [[2]](diffhunk://#diff-c1bb2180a9c1a5434b1f5daeda984091432f1f212bd36a43f9a5e275b14dd5f7L139-R136) [[3]](diffhunk://#diff-c1bb2180a9c1a5434b1f5daeda984091432f1f212bd36a43f9a5e275b14dd5f7L162-R159) [[4]](diffhunk://#diff-c1bb2180a9c1a5434b1f5daeda984091432f1f212bd36a43f9a5e275b14dd5f7L218-R215)

**Lucene codec filename case restoration:**
- Added logic in `CmsIODirectory` to restore the original mixed-case codec names in filenames that were lowercased by CMS.IO storage backends. This ensures Lucene's file operations (like deletion) work correctly by matching the expected casing. [[1]](diffhunk://#diff-ff082c67577f490e9b3263c0db337ce8f6dfe979f8c80eebf88ba22f34cde8e6R25-R33) [[2]](diffhunk://#diff-ff082c67577f490e9b3263c0db337ce8f6dfe979f8c80eebf88ba22f34cde8e6R82-R92) [[3]](diffhunk://#diff-ff082c67577f490e9b3263c0db337ce8f6dfe979f8c80eebf88ba22f34cde8e6R280-R340)
- Implemented a static, lazily-initialized lookup of registered codec and format names from Lucene's factories to support the case restoration. [[1]](diffhunk://#diff-ff082c67577f490e9b3263c0db337ce8f6dfe979f8c80eebf88ba22f34cde8e6R25-R33) [[2]](diffhunk://#diff-ff082c67577f490e9b3263c0db337ce8f6dfe979f8c80eebf88ba22f34cde8e6R280-R340)

**Info model enhancements:**
- Updated `LuceneIndexItemInfo` to implement `IInfoWithName` and `IInfoWithId`, and added an `[InfoCache]` attribute for improved caching and identification.# Motivation

Which issue does this fix? Fixes #`issue number`

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

## Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

If manual testing is required, what are the steps?
