### PR TITLE
Update version suffix from prerelease-1 to prerelease-2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
     <VersionPrefix>15.0.2</VersionPrefix>
-    <VersionSuffix>prerelease-1</VersionSuffix>
+    <VersionSuffix>prerelease-2</VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
     <PackageProjectUrl>https://github.com/Kentico/xperience-by-kentico-lucene</PackageProjectUrl>


### PR DESCRIPTION
This pull request makes a small update to the project versioning by incrementing the prerelease suffix from "prerelease-1" to "prerelease-2" in the `Directory.Build.props` file.# Motivation

