### PR TITLE
Updated CmsIOIndexInput to seek to the current position on clone

### DIFF
--- a/src/Kentico.Xperience.Lucene.Core/Store/CmsIOIndexInput.cs
+++ b/src/Kentico.Xperience.Lucene.Core/Store/CmsIOIndexInput.cs
@@ -124,14 +124,18 @@ internal class CmsIOIndexInput : BufferedIndexInput
     /// Cloning also file streams would lead to multiple readers on the same stream, which is not thread-safe and Azure forbids it.
     /// Therefore, clones share the same stream and synchronize access to it.
     /// </remarks>
-    public override object Clone() =>
-        new CmsIOIndexInput(
+    public override object Clone()
+    {
+        var clone = new CmsIOIndexInput(
             $"CmsIOIndexInput(path=\"{path}\") [clone]",
             path,
             stream!,
             length,
             BufferSize,
             streamLock);
+        clone.Seek(Position);
+        return clone;
+    }
 
 
     /// <summary>


### PR DESCRIPTION
Updated clone behaviour to seek to current position.

Addresses issue https://github.com/Kentico/xperience-by-kentico-lucene/issues/197