### PR TITLE
Allow reindexing after failed load

### DIFF
--- a/src/Kentico.Xperience.Lucene.Admin/UIPages/IndexListingPage.cs
+++ b/src/Kentico.Xperience.Lucene.Admin/UIPages/IndexListingPage.cs
@@ -91,7 +91,16 @@ public class IndexListingPage : ListingPage
     {
         var result = await base.LoadData(settings, cancellationToken);
 
-        var statistics = await luceneClient.GetStatistics(default);
+        ICollection<LuceneIndexStatisticsModel> statistics = [];
+        try
+        {
+            statistics = await luceneClient.GetStatistics(default);
+        }
+        catch (Exception ex)
+        {
+            EventLogService.LogException(nameof(IndexListingPage), nameof(LoadData), ex);
+        }
+
         // Add statistics for indexes that are registered but not created in Lucene
         AddMissingStatistics(ref statistics, indexManager);
 

--- a/src/Kentico.Xperience.Lucene.Admin/UIPages/IndexListingPage.cs
+++ b/src/Kentico.Xperience.Lucene.Admin/UIPages/IndexListingPage.cs
@@ -94,7 +94,11 @@ public class IndexListingPage : ListingPage
         ICollection<LuceneIndexStatisticsModel> statistics = [];
         try
         {
-            statistics = await luceneClient.GetStatistics(default);
+            statistics = await luceneClient.GetStatistics(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
This pull request improves the reliability of the `LoadData` method in `IndexListingPage` by adding robust error handling when retrieving Lucene index statistics. The main change ensures that exceptions are properly logged and handled, preventing unexpected crashes during data loading.

Error handling improvements:

* Updated the call to `luceneClient.GetStatistics` to use the provided `cancellationToken` and wrapped it in a try-catch block to handle exceptions gracefully. Canceled operations are rethrown, while other exceptions are logged using `EventLogService.LogException`.
