### PR TITLE
Bump version prefix from 15.0.4 to 15.0.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 		<Authors>$(Company)</Authors>
 		<Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
 		<Trademark>$(Company)™</Trademark>
-		<VersionPrefix>15.0.4</VersionPrefix>
+		<VersionPrefix>15.0.5</VersionPrefix>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 
 		<PackageProjectUrl>https://github.com/Kentico/xperience-by-kentico-lucene</PackageProjectUrl>


### PR DESCRIPTION
This pull request updates the package version in the project configuration.

Version update:

* Increased the `VersionPrefix` in `Directory.Build.props` from `15.0.4` to `15.0.5` to prepare for a new release.
